### PR TITLE
smarthome Tasmota: changed json reporting since version 14.x

### DIFF
--- a/packages/modules/smarthome/tasmota/watt.py
+++ b/packages/modules/smarthome/tasmota/watt.py
@@ -2,6 +2,7 @@
 import sys
 import time
 import json
+import jq
 import urllib.request
 named_tuple = time.localtime()  # getstruct_time
 time_string = time.strftime("%m/%d/%Y, %H:%M:%S tasmota watty.py", named_tuple)
@@ -9,21 +10,31 @@ devicenumber = str(sys.argv[1])
 ipadr = str(sys.argv[2])
 uberschuss = int(sys.argv[3])
 relais = 0
+jsonurl1 = "http://"+str(ipadr)+"/cm?cmnd=Status%2011"
+jsonurl2 = "http://"+str(ipadr)+"/cm?cmnd=Status%208"
+jsonpow = ".StatusSTS.POWER"    # response on a single relais config
+jsonpow1 = ".StatusSTS.POWER1"  # response for first relais on a multi relais config
+
 try:
-    answer2 = json.loads(str(urllib.request.urlopen("http://"+str(ipadr) +
-                         "/cm?cmnd=Status", timeout=3).read().decode("utf-8")))
-    r_status = int(answer2['Status']['Power'])
+    answer = json.loads(str(urllib.request.urlopen(jsonurl1, timeout=3).read().decode("utf-8")))
+    r_status = jq.compile(jsonpow).input(answer).first()
+    if r_status == None:
+        r_status = jq.compile(jsonpow1).input(answer).first()
+    if r_status == None:
+        r_status = "OFF"
 except Exception:
-    r_status = 0
-answer = json.loads(str(urllib.request.urlopen("http://"+str(ipadr) +
-                    "/cm?cmnd=Status%208", timeout=3).read().decode("utf-8")))
+    r_status = "OFF"
+
 try:
-    aktpower = int(answer['StatusSNS']['ENERGY']['Power'])
+    answer = json.loads(str(urllib.request.urlopen(jsonurl2, timeout=3).read().decode("utf-8")))
+    aktpower = int(answer['StatusSNS']['ANALOG']['CTEnergy']['Power'])
+    powerc = int((answer['StatusSNS']['ANALOG']['CTEnergy']['Energy']) * 1000)
 except Exception:
     aktpower = 0
-if (aktpower > 50) or (r_status == 1):
+    powerc = 0
+
+if (aktpower > 50) or (r_status == "ON"):
     relais = 1
-powerc = 0
 answer = '{"power":' + str(aktpower) + ',"powerc":' + str(powerc) + ',"on":' + str(relais) + '} '
 f1 = open('/var/www/html/openWB/ramdisk/smarthome_device_ret' + str(devicenumber), 'w')
 json.dump(answer, f1)


### PR DESCRIPTION
Since Tasmota version 14.x the json reporting is changed and it seems to be the case this beeing the new standard there.
The documentation regarding this however seems to be weak.
For smarthome devices based on Tasmota the actual power and power state is requested in "watt.py" by using the response of the Status command.
The response for "Status" changed regarding the power state from an integer value (e.g. ...,"Power":3,.....) representing the power state of all configured relais to a string value showing each relais in a bitwise state (e.g. ...,"Power":"011",.....).
As a result the script "watt.py" is no longer able to determine the power state correctly.

My working solution is as attached file watt.py and has an addition to report also the consumed energy.
This works for Tasmota version 12.x/13.x and 14.x as well, assuming the primary relais controlled by openWB is always the first (or only) relais and is reported as "POWER" or "POWER1" by "Status 11" command.